### PR TITLE
handle multiple events with the same normalized form

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -3,6 +3,7 @@ const abiDecoder = require("../index.js");
 
 // Test Params
 const testABI = [{"inputs": [{"type": "address", "name": ""}], "constant": true, "name": "isInstantiation", "payable": false, "outputs": [{"type": "bool", "name": ""}], "type": "function"}, {"inputs": [{"type": "address[]", "name": "_owners"}, {"type": "uint256", "name": "_required"}, {"type": "uint256", "name": "_dailyLimit"}], "constant": false, "name": "create", "payable": false, "outputs": [{"type": "address", "name": "wallet"}], "type": "function"}, {"inputs": [{"type": "address", "name": ""}, {"type": "uint256", "name": ""}], "constant": true, "name": "instantiations", "payable": false, "outputs": [{"type": "address", "name": ""}], "type": "function"}, {"inputs": [{"type": "address", "name": "creator"}], "constant": true, "name": "getInstantiationCount", "payable": false, "outputs": [{"type": "uint256", "name": ""}], "type": "function"}, {"inputs": [{"indexed": false, "type": "address", "name": "sender"}, {"indexed": false, "type": "address", "name": "instantiation"}], "type": "event", "name": "ContractInstantiation", "anonymous": false}];
+const testABIDuplicateEvent = [{"inputs": [{"indexed": true, "type": "address", "name": "sender"}, {"indexed": true, "type": "address", "name": "instantiation"}], "type": "event", "name": "ContractInstantiation", "anonymous": false}];
 const testArrNumbersABI = [{"constant":false,"inputs":[{"name":"n","type":"uint256[]"}],"name":"numbers","outputs":[{"name":"","type":"uint256"}],"payable":false,"stateMutability":"nonpayable","type":"function"}];
 
 describe("abi decoder", function () {
@@ -14,9 +15,10 @@ describe("abi decoder", function () {
 
   it("add abis", () => {
     abiDecoder.addABI(testABI);
+    abiDecoder.addABI(testABIDuplicateEvent);
     const abis = abiDecoder.getABIs();
     expect(abis).to.be.an("array");
-    expect(abis).to.have.length(5);
+    expect(abis).to.have.length(6);
     const methodIDs = abiDecoder.getMethodIDs();
     expect(methodIDs).to.be.an("object");
     expect(Object.keys(methodIDs)).to.have.length(5);


### PR DESCRIPTION
In case that multiple Abis are loaded, and there is an event in multiple forms (with/without indexed arguments). This commit tries to handle all cases and returns the first one that succeed or undefined otherwise.

In previous version, an exception is thrown although a valid ABI is supplied since the last loaded ABI overrides the previous ones

Fixes ConsenSys/abi-decoder/#43